### PR TITLE
fix: revert swc to prevent "check" crash

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,6 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
  **/
 
 const nextConfig = {
-  swcMinify: true,
   reactStrictMode: true,
   images: {
     domains: [


### PR DESCRIPTION
Some issue with using swcMinify causing crash on /blog/slug page.
"check" not defined.